### PR TITLE
Add 2.1.35

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ on "Downgrade & Quit". If you skip this step, you may get an error message when
 opening your collection in an older Anki version, and you will need to return to
 this version, downgrade, then try again.
 
+## Changes in 2.1.35
+
+Released 2020-10-02, build 84dcaa86.
+
+- Fix issue where special characters (*, %, _) in the browser sidebar search terms are not escaped.
+- Fix previewer not refreshing when selecting multiple cards in browser.
+- Fix black area on alternate Mac build for line graph graphics.
+
+
 ## Changes in 2.1.34
 
 Released 2020-09-24, build 8af8f565.


### PR DESCRIPTION
Build checks for adding 2.1.35 to Homebrew (https://github.com/Homebrew/homebrew-cask/pull/90228) is currently failing because the changelog does not mention 2.1.35 (this is one of the CI checks). This PR adds some to start with (expecting to be edited).